### PR TITLE
Azure pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: xenial
+language: rust
+addons:
+  apt:
+    packages:
+      - libsystemd-dev
+      - libapt-pkg-dev
+      - libclang-dev
+      - pkg-config
+      - libdbus-1-dev
+      - liblzma-dev
+rust:
+  - nightly
+script:
+  - cargo build --verbose --all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,35 @@
+---
+resources:
+  containers:
+    - container: xenial
+      image: 'ubuntu:16.04'
+
+jobs:
+- job: release
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    matrix:
+      xenial:
+        containerResource: xenial
+  container: $[ variables['containerResource'] ]
+  steps:
+    - script: |
+        apt-get update
+        apt-get install -yq libsystemd-dev libdbus-1-dev
+      displayName: Install dependencies
+    - script: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+      displayName: Install Rust toolchain
+    - script: cargo install cargo-deb
+      displayName: Install cargo-deb
+    - script: cargo deb
+      displayName: Build package
+    - task: CopyFiles@2
+      inputs:
+        contents: '$(System.DefaultWorkingDirectory)/target/debian'
+        targetFolder: $(Build.ArtifactStagingDirectory)
+      displayName: 'Copy package'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        artifactName: $(containerResource)
+        displayName: 'Upload artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         containerResource: xenial
   container: $[ variables['containerResource'] ]
   steps:
-    - script: . /opt/rustup/env && sudo -E cargo deb
+    - script: . /opt/rustup/env && cargo deb
       displayName: Build package
     - task: CopyFiles@2
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         containerResource: xenial
   container: $[ variables['containerResource'] ]
   steps:
-    - script: . /opt/rustup/env && cargo deb
+    - script: . /opt/rustup/env && sudo -E cargo deb
       displayName: Build package
     - task: CopyFiles@2
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,7 @@
 resources:
   containers:
     - container: xenial
-      image: 'ubuntu:16.04'
-      options: '--user 0'
+      image: 'glaux/update-broker-build-deps:16.04'
 
 jobs:
 - job: release
@@ -15,14 +14,6 @@ jobs:
         containerResource: xenial
   container: $[ variables['containerResource'] ]
   steps:
-    - script: |
-        apt-get update
-        apt-get install -yq libsystemd-dev libdbus-1-dev
-      displayName: Install dependencies
-    - script: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-      displayName: Install Rust toolchain
-    - script: cargo install cargo-deb
-      displayName: Install cargo-deb
     - script: cargo deb
       displayName: Build package
     - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,8 @@ jobs:
   container: $[ variables['containerResource'] ]
   steps:
     - script: |
-        apt-get update
-        apt-get install -yq libsystemd-dev libdbus-1-dev
+        sudo apt-get update
+        sudo apt-get install -yq libsystemd-dev libdbus-1-dev
       displayName: Install dependencies
     - script: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
       displayName: Install Rust toolchain

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ resources:
   containers:
     - container: xenial
       image: 'ubuntu:16.04'
+      options: '--user 0'
 
 jobs:
 - job: release
@@ -15,8 +16,8 @@ jobs:
   container: $[ variables['containerResource'] ]
   steps:
     - script: |
-        sudo apt-get update
-        sudo apt-get install -yq libsystemd-dev libdbus-1-dev
+        apt-get update
+        apt-get install -yq libsystemd-dev libdbus-1-dev
       displayName: Install dependencies
     - script: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
       displayName: Install Rust toolchain

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,8 @@ resources:
   containers:
     - container: xenial
       image: 'glaux/update-broker-build-deps:16.04'
-
+    - container: bionic
+      image: 'glaux/update-broker-build-deps:18.04'
 jobs:
 - job: release
   pool:
@@ -12,13 +13,15 @@ jobs:
     matrix:
       xenial:
         containerResource: xenial
+      bionic:
+        containerResource: bionic
   container: $[ variables['containerResource'] ]
   steps:
     - script: . /opt/rustup/env && cargo deb
       displayName: Build package
     - task: CopyFiles@2
       inputs:
-        contents: '$(System.DefaultWorkingDirectory)/target/debian'
+        contents: '$(System.DefaultWorkingDirectory)/target/debian/*.deb'
         targetFolder: $(Build.ArtifactStagingDirectory)
       displayName: 'Copy package'
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         containerResource: xenial
   container: $[ variables['containerResource'] ]
   steps:
-    - script: cargo deb
+    - script: . /opt/rustup/env && cargo deb
       displayName: Build package
     - task: CopyFiles@2
       inputs:


### PR DESCRIPTION
This adds support for using Azure Pipelines to build packages for different Ubuntu versions (currently, that's both of the systemd-based LTS versions). There is also a part to this which actually performs releases, but unfortunately, that's configured on the Azure side.